### PR TITLE
Fix broken add new artwork and broken API POST create()

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -30,7 +30,7 @@ class ArtistSerializer(serializers.ModelSerializer):
 
         instance.save()
 
-     
+        return instance
 
 
     

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from rest_framework_swagger.views import get_swagger_view
 from api.views import ArtistViewSet
 
 API_TITLE = 'met API'
-API_DESC = 'A web API for creating, modifying and deleting Metropolitan Museum of Art.'
+API_DESC = 'A web API for creating, modifying and deleting Met artists.'
 
 docs_view = include_docs_urls(
 	title=API_TITLE,
@@ -24,7 +24,7 @@ schema_view = get_schema_view(
 '''
 
 router = SimpleRouter()
-router.register(r'sites', ArtistViewSet, base_name='sites')
+router.register(r'artists', ArtistViewSet, base_name='artists')
 # urlpatterns = router.urls
 
 # The API URLs are now determined automatically by the router.

--- a/met/views.py
+++ b/met/views.py
@@ -52,12 +52,6 @@ class ArtDetailView(generic.DetailView):
 		artwork = super().get_object()
 		return artwork
 
-
-
-
-
-
-
 @method_decorator(login_required, name='dispatch')
 class ArtCreateView(generic.View):
 	model = Artwork
@@ -76,16 +70,12 @@ class ArtCreateView(generic.View):
 			art = form.save(commit=False)
 			art.save()
 			i = 0
-			
-			if form.cleaned_data['artist'] in form_class:
-				for artist in form.cleaned_data['artist']:
 
-					ArtworkArtist.objects.create(artwork=art, artist=artist, artwork_artist_index=i)
-					i+=1
-			
-				return redirect(art) # shortcut to object's get_absolute_url()
-			else:
-				return redirect(art)
+			for artist in form.cleaned_data['artist']:
+				ArtworkArtist.objects.create(artwork=art, artist=artist, artwork_artist_index=i)
+				i += 1
+			return redirect(art) # shortcut to object's get_absolute_url()
+
 			# return HttpResponseRedirect(site.get_absolute_url())
 		return render(request, 'met/art_new.html', {'form': form})
 


### PR DESCRIPTION
This PR fixes the following:

* `api/serializers.py`: missing create() return value
* `api/urls.py`: provides a more descriptive path name for the operation
* `met/views.py`: removes bad if() check in `ArtCreateView(generic.View)`  `def post()`